### PR TITLE
Add python3.8 and github's commandline api

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,11 @@ FROM ros:kinetic-ros-base-xenial as vision_project_min
 
 # Pass in a command line arguement to set the branch to use
 # e.g., docker build --build-arg vision_project_branch=master --target vision_project_dev .
-ARG vision_project_branch=master
+ARG vision_project_branch="master"
 
-ENV ROS_WS /root/catkin_ws
+# Environment variables
+ENV PYTHON3_VERSION="python3.8"
+ENV ROS_WS="/root/catkin_ws"
 
 # TODO: see if this can be deleted
 # Setup new ROS key + install ros packages
@@ -50,6 +52,25 @@ RUN \
 		boto3==1.12.11 \
 		soundfile==0.10.3.post1 \
 		speedtest-cli==2.1.2 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Setup Python3 for vision-project
+RUN \
+	apt-get update -y \
+	&& apt-get install -y \
+		software-properties-common \
+		curl \
+	&& add-apt-repository ppa:deadsnakes/ppa -y \
+	&& apt-get update \
+	&& apt-get install -y \
+		${PYTHON3_VERSION} \
+		${PYTHON3_VERSION}-dev \
+		${PYTHON3_VERSION}-venv \
+	# Setup pip
+	&& curl https://bootstrap.pypa.io/get-pip.py | sudo python3.8 \
+	&& ${PYTHON3_VERSION} -m pip install \
+		rospkg \
+		catkin_pkg \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Setup HTTP server
@@ -138,15 +159,28 @@ RUN \
 	&& apt-get install -y code \
 	&& rm -rf /var/lib/apt/lists/* 
 
+# Setup Github command line tool
+RUN \
+	apt-get update \
+	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
+	&& apt-add-repository https://cli.github.com/packages \
+	&& apt-get update \
+	&& apt-get install -y \
+		gh \
+	&& rm -rf /var/lib/apt/lists/*
+
 # Put things you want in your ~/.bashrc here
 RUN \
 	unset DEBIAN_FRONTEND \
 	&& echo " \
-alias gs='git status'\n\
-alias gl='git log --pretty=oneline --graph'\n\
 alias gb='git branch -a'\n\
-alias gg='git gui'\n\
+alias gcb='git checkout -b '\n\
 alias gd='git diff HEAD'\n\
+alias gg='git gui'\n\
+alias gl='git log --pretty=oneline --graph'\n\
+alias rh='cd $ROS_PATH'\n\
+alias gs='git status'\n\
 alias code='code --user-data-dir /root/.visual_code/'\n\
+alias STRESS='stress -c $(nproc) -m $(nproc) -i $(nproc) -d $(nproc)'\n\
 source ${ROS_WS}/devel/setup.bash\n\
 " >> ~/.bashrc

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,11 +26,12 @@ services:
       - visual_code_plugins:/root/.vscode/
       - visual_code_user_data:/root/.visual_code/
       - ./shared/:/root/shared/
-      - ~/.gitconfig/:/root/.gitconfig/:ro
-      - ~/.vimrc/:/root/.vimrc/:ro
-      - ~/.vim/:/root/.vim/:ro
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+      - ~/.config/gh/:/root/.config/gh/:ro
+      - ~/.gitconfig/:/root/.gitconfig/:ro
+      - ~/.vim/:/root/.vim/:ro
+      - ~/.vimrc/:/root/.vimrc/:ro
     working_dir: /root/
 
 volumes:


### PR DESCRIPTION
This PR adds a Python3.8 in a way that works with ROS, as well as installs [Github's command line interface](https://cli.github.com/) for the `*dev` image in the Docker file.
