### PR TITLE
Fix CI error after Github update

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -13,10 +13,10 @@ jobs:
 
       - name: Set branch name for pull request
         if: github.event_name == 'pull_request'
-        run: echo "::set-env name=BRANCH_NAME::${{github.event.pull_request.head.ref}}"
+        run: echo "BRANCH_NAME=${{github.event.pull_request.head.ref}}" >> $GITHUB_ENV
       - name: Set branch name
         if: github.event_name != 'pull_request'
-        run: echo "::set-env name=BRANCH_NAME::${GITHUB_REF#refs/heads/}"
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Echo branch name
         run: echo ${BRANCH_NAME}
 


### PR DESCRIPTION
Github found a security issue and deprecated `::set-env` which we were using in CI (see [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)). This PR addresses this issue using their proposed work around so that CI passes again.