### PR TITLE
Specify version of pip that works with Python 2.7

### DIFF
--- a/docker/scripts/install_deps.sh
+++ b/docker/scripts/install_deps.sh
@@ -36,7 +36,7 @@ sudo apt-get install -y \
 	python-gst0.10 \
 	python-mock \
 	python-pyaudio
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip==20.3.3
 python -m pip install \
 	rospkg \
 	catkin_pkg \


### PR DESCRIPTION
The latest pip versions (20.3.4 and 21.0) are no longer compatible with Python 2.7. I've specified a version of pip in the dependencies installation script to make sure that the Docker container runs without issues.