### PR TITLE
Add reading evaluator node

### DIFF
--- a/docker/scripts/install_deps.sh
+++ b/docker/scripts/install_deps.sh
@@ -66,7 +66,9 @@ ${PYTHON3_VERSION} -m pip install --user \
 	schedule==0.6.0 \
 	pydub==0.25.1 \
 	pymongo==3.11.4 \
-	discord.py==1.7.1
+	discord.py==1.7.1 \
+	speechrecognition \
+	webrtcvad
 
 
 # Setup HTTP server

--- a/src/ros_vision_interaction/config/config.yaml
+++ b/src/ros_vision_interaction/config/config.yaml
@@ -1,6 +1,8 @@
 mongodb:
   host: 'localhost'
   port: 62345
+  database_name: "vision_project"
+  collection_name: "state_db"
 vision-project:
   controllers:
     is_debug: False

--- a/src/ros_vision_interaction/launch/vision_project.launch
+++ b/src/ros_vision_interaction/launch/vision_project.launch
@@ -1,5 +1,6 @@
 <launch>
     <arg name="is_launch_controllers" default="true"/>
+    <arg name="is_launch_evaluator" default="true"/>
     <arg name="aws_voice_name" default="Justin"/>
     <arg name="face_port" default="8081"/>
     <arg name="gui_port" default="8082"/>
@@ -86,6 +87,11 @@
     <group if="$(arg is_launch_controllers)">
         <node pkg="ros_vision_interaction" type="ros_vision_project_delegator.py" name="vision_project_delegator" output="screen"/>
         <node pkg="ros_vision_interaction" type="ros_interaction_manager.py" name="interaction_manager" output="screen"/>
+    </group>
+
+    <!-- launch reading evaluator -->
+    <group if="$(arg is_launch_evaluator)">
+        <node pkg="ros_vision_interaction" type="ros_reading_evaluator.py" name="reading_evaluator" output="screen"/>
     </group>
 
     <!-- launch mongodb log -->

--- a/src/ros_vision_interaction/scripts/ros_interaction_manager.py
+++ b/src/ros_vision_interaction/scripts/ros_interaction_manager.py
@@ -7,10 +7,10 @@ import pymongo
 import rospy
 
 from controllers import InteractionManager
-from controllers.vision_project_delegator import DatabaseKeys, INITIAL_STATE_DB
 from interaction_builder import InteractionBuilder
 from interfaces import CordialInterface
 from vision_project_tools import init_db
+from vision_project_tools.constants import DatabaseKeys, INITIAL_STATE_DB
 from vision_project_tools.engine_statedb import EngineStateDb as StateDb
 
 from ros_vision_interaction.msg import StartInteractionAction, StartInteractionResult

--- a/src/ros_vision_interaction/scripts/ros_interaction_manager.py
+++ b/src/ros_vision_interaction/scripts/ros_interaction_manager.py
@@ -7,7 +7,7 @@ import pymongo
 import rospy
 
 from controllers import InteractionManager
-from controllers.vision_project_delegator import INITIAL_STATE_DB
+from controllers.vision_project_delegator import DatabaseKeys, INITIAL_STATE_DB
 from interaction_builder import InteractionBuilder
 from interfaces import CordialInterface
 from vision_project_tools import init_db
@@ -48,7 +48,7 @@ class RosInteractionManager:
 
     # start interaction action callback
     def run_manager_once(self, goal):
-        self._state_database.set("is interaction finished", False)
+        self._state_database.set(DatabaseKeys.IS_INTERACTION_FINISHED, False)
         interaction_type = goal.type
         result = StartInteractionResult()
 
@@ -75,13 +75,14 @@ if __name__ == "__main__":
 
     seconds_until_timeout = rospy.get_param("vision-project/params/seconds_until_interaction_timeout")
 
-    DATABASE_NAME = "vision-project"
     host = rospy.get_param("mongodb/host")
     port = rospy.get_param("mongodb/port")
+    database_name = rospy.get_param("mongodb/database_name")
+    collection_name = rospy.get_param("mongodb/collection_name")
     state_database = StateDb(
         pymongo.MongoClient(host, port),
-        database_name=DATABASE_NAME,
-        collection_name="state_db"
+        database_name=database_name,
+        collection_name=collection_name
     )
     init_db(state_database, INITIAL_STATE_DB)
 

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -9,7 +9,7 @@ import time
 from std_msgs.msg import Bool
 from vision_project_tools import init_db
 from vision_project_tools import EngineStateDb as StateDb
-from controllers.vision_project_delegator import INITIAL_STATE_DB
+from controllers.vision_project_delegator import DatabaseKeys, INITIAL_STATE_DB
 from reading_evaluator import ReadingEvaluator
 
 sys.path.append('/root/catkin_ws/src/ffmpeg')
@@ -55,9 +55,9 @@ class RosReadingEvaluator:
             )
             reading_time = self._reading_evaluator.get_total_speaking_time(audio_file)
             rospy.loginfo(f"Reading time: {reading_time}")
-            reading_eval_index = self._state_database.get("reading eval index")
+            reading_eval_index = self._state_database.get(DatabaseKeys.READING_EVAL_INDEX)
             try:
-                num_of_words = self._state_database.get("reading eval data")[reading_eval_index]["word count"]
+                num_of_words = self._state_database.get(DatabaseKeys.READING_EVAL_DATA)[reading_eval_index]["word count"]
             except IndexError or KeyError:
                 rospy.logerr(f"Reading task data not found for index:{reading_eval_index}")
                 num_of_words = 0
@@ -68,7 +68,7 @@ class RosReadingEvaluator:
             else:
                 reading_speed = num_of_words / reading_time
                 rospy.loginfo("Reading speed: {}".format(reading_speed))
-            self._state_database.set("current eval score", reading_speed)
+            self._state_database.set(DatabaseKeys.CURRENT_EVAL_SCORE, reading_speed)
 
     def find_audio_file(
             self,

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -61,12 +61,13 @@ class RosReadingEvaluator:
             except IndexError or KeyError:
                 rospy.logerr(f"Reading task data not found for index:{reading_eval_index}")
                 num_of_words = 0
-            try:
-                reading_speed = num_of_words / reading_time
-                rospy.loginfo("Reading speed: {}".format(reading_speed))
-            except ZeroDivisionError:
+
+            if reading_time == 0:
                 rospy.logerr("Reading time is 0, setting reading speed to 0")
                 reading_speed = 0
+            else:
+                reading_speed = num_of_words / reading_time
+                rospy.loginfo("Reading speed: {}".format(reading_speed))
             self._state_database.set("current eval score", reading_speed)
 
     def find_audio_file(

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -9,7 +9,7 @@ import time
 from std_msgs.msg import Bool
 from vision_project_tools import init_db
 from vision_project_tools import EngineStateDb as StateDb
-from controllers.vision_project_delegator import DatabaseKeys, INITIAL_STATE_DB
+from vision_project_tools.constants import DatabaseKeys, INITIAL_STATE_DB
 from reading_evaluator import ReadingEvaluator
 
 sys.path.append('/root/catkin_ws/src/ffmpeg')

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -93,13 +93,14 @@ class RosReadingEvaluator:
 
 if __name__ == "__main__":
     rospy.init_node("reading_evaluator")
-    DATABASE_NAME = "vision-project"
     host = rospy.get_param("mongodb/host")
     port = rospy.get_param("mongodb/port")
+    database_name = rospy.get_param("mongodb/database_name")
+    collection_name = rospy.get_param("mongodb/collection_name")
     state_database = StateDb(
         pymongo.MongoClient(host, port),
-        database_name=DATABASE_NAME,
-        collection_name="state_db"
+        database_name=database_name,
+        collection_name=collection_name
     )
     init_db(state_database, INITIAL_STATE_DB)
 

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -106,10 +106,7 @@ if __name__ == "__main__":
 
     source_directory = rospy.get_param("vision-project/data/data_capture")
 
-    reading_evaluator = ReadingEvaluator(
-        silence_threshold=-40,
-        chunk_size=10
-    )
+    reading_evaluator = ReadingEvaluator()
 
     ros_evaluator = RosReadingEvaluator(
         statedb=state_database,

--- a/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
+++ b/src/ros_vision_interaction/scripts/ros_reading_evaluator.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3.8
+import glob
+import os
+import pymongo
+import rospy
+import sys
+import time
+
+from std_msgs.msg import Bool
+from vision_project_tools import init_db
+from vision_project_tools import EngineStateDb as StateDb
+from controllers.vision_project_delegator import INITIAL_STATE_DB
+from reading_evaluator import ReadingEvaluator
+
+sys.path.append('/root/catkin_ws/src/ffmpeg')
+
+
+class RosReadingEvaluator:
+
+    def __init__(
+            self,
+            statedb,
+            reading_evaluator,
+            source_directory,
+            file_prefix,
+            extension="wav",
+            seconds_to_check_for_audio_files=5
+    ):
+        if not os.path.exists(source_directory):
+            raise FileNotFoundError("The upload directory \'{}\' does not exist".format(source_directory))
+
+        self._source_directory = source_directory
+        self._file_prefix = file_prefix
+        self._extension = extension
+        self._seconds_to_check_for_audio_files = seconds_to_check_for_audio_files
+
+        is_record_evaluation_topic = rospy.get_param("controllers/is_record/evaluation")
+        self._is_record_subscriber = rospy.Subscriber(
+            is_record_evaluation_topic,
+            Bool,
+            callback=self.reading_analyzer_callback,
+            queue_size=1
+        )
+
+        self._state_database = statedb
+        self._reading_evaluator = reading_evaluator
+
+    def reading_analyzer_callback(self, is_record):
+        if not is_record.data:
+            rospy.loginfo("Evaluator callback starting")
+            audio_file = self.find_audio_file(
+                self._source_directory,
+                self._extension,
+                self._file_prefix
+            )
+            reading_time = self._reading_evaluator.get_total_speaking_time(audio_file)
+            rospy.loginfo(f"Reading time: {reading_time}")
+            reading_eval_index = self._state_database.get("reading eval index")
+            try:
+                num_of_words = self._state_database.get("reading eval data")[reading_eval_index]["word count"]
+            except IndexError or KeyError:
+                rospy.logerr(f"Reading task data not found for index:{reading_eval_index}")
+                num_of_words = 0
+            try:
+                reading_speed = num_of_words / reading_time
+                rospy.loginfo("Reading speed: {}".format(reading_speed))
+            except ZeroDivisionError:
+                rospy.logerr("Reading time is 0, setting reading speed to 0")
+                reading_speed = 0
+            self._state_database.set("current eval score", reading_speed)
+
+    def find_audio_file(
+            self,
+            directory,
+            extension,
+            file_prefix
+    ):
+        """Finds a file based on the directory, location, and file prefix.
+        Returns the first occurrence of a valid file path."""
+        list_of_audio_files = []
+        for _ in range(self._seconds_to_check_for_audio_files):
+            list_of_audio_files = glob.glob(os.path.join(directory, "*." + extension))
+            if len(list_of_audio_files) > 0 and \
+                    any(file_prefix in string for string in list_of_audio_files):
+                break
+            time.sleep(0.2)
+        for file in list_of_audio_files:
+            if file.find(file_prefix) >= 0:
+                return file
+        rospy.loginfo("No matching files found, returning None")
+        return None
+
+
+if __name__ == "__main__":
+    rospy.init_node("reading_evaluator")
+    DATABASE_NAME = "vision-project"
+    host = rospy.get_param("mongodb/host")
+    port = rospy.get_param("mongodb/port")
+    state_database = StateDb(
+        pymongo.MongoClient(host, port),
+        database_name=DATABASE_NAME,
+        collection_name="state_db"
+    )
+    init_db(state_database, INITIAL_STATE_DB)
+
+    source_directory = rospy.get_param("vision-project/data/data_capture")
+
+    reading_evaluator = ReadingEvaluator(
+        silence_threshold=-40,
+        chunk_size=10
+    )
+
+    ros_evaluator = RosReadingEvaluator(
+        statedb=state_database,
+        source_directory=source_directory,
+        file_prefix="evaluation",
+        extension="wav",
+        reading_evaluator=reading_evaluator
+    )
+
+    rospy.spin()

--- a/src/ros_vision_interaction/scripts/ros_vision_project_delegator.py
+++ b/src/ros_vision_interaction/scripts/ros_vision_project_delegator.py
@@ -165,13 +165,14 @@ if __name__ == "__main__":
 
     rospy.init_node("vision_project_delegator")
 
-    DATABASE_NAME = "vision-project"
     host = rospy.get_param("mongodb/host")
     port = rospy.get_param("mongodb/port")
+    database_name = rospy.get_param("mongodb/database_name")
+    collection_name = rospy.get_param("mongodb/collection_name")
     state_database = StateDb(
         pymongo.MongoClient(host, port),
-        database_name=DATABASE_NAME,
-        collection_name="state_db"
+        database_name=database_name,
+        collection_name=collection_name
     )
     init_db(state_database, INITIAL_STATE_DB)
 

--- a/src/ros_vision_interaction/scripts/ros_vision_project_delegator.py
+++ b/src/ros_vision_interaction/scripts/ros_vision_project_delegator.py
@@ -6,9 +6,9 @@ import rospy
 import schedule
 
 from controllers import VisionProjectDelegator
-from controllers.vision_project_delegator import DatabaseKeys, INITIAL_STATE_DB
 from interaction_builder import InteractionBuilder
 from vision_project_tools import init_db
+from vision_project_tools.constants import DatabaseKeys, INITIAL_STATE_DB
 from vision_project_tools.engine_statedb import EngineStateDb as StateDb
 
 from cordial_msgs.msg import MouseEvent

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/interaction_manager.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/interaction_manager.py
@@ -2,32 +2,13 @@
 import datetime
 import logging
 
-from controllers.vision_project_delegator import DatabaseKeys
 from interaction_engine.interfaces import TerminalClientAndServerInterface
 from interaction_engine.planner import MessagerPlanner
 from interaction_builder import InteractionBuilder
+from vision_project_tools.constants import Interactions, DatabaseKeys
 from vision_project_tools.vision_engine import VisionInteractionEngine as InteractionEngine
 
 logging.basicConfig(level=logging.INFO)
-
-
-class Interactions:
-
-    ASK_TO_DO_SCHEDULED = "ask to do scheduled"
-    EVALUATION = "evaluation"
-    FIRST_INTERACTION = "first interaction"
-    PROMPTED_INTERACTION = "prompted interaction"
-    SCHEDULED_INTERACTION = "scheduled interaction"
-    TOO_MANY_PROMPTED = "too many prompted"
-
-    POSSIBLE_INTERACTIONS = [
-        ASK_TO_DO_SCHEDULED,
-        EVALUATION,
-        FIRST_INTERACTION,
-        PROMPTED_INTERACTION,
-        SCHEDULED_INTERACTION,
-        TOO_MANY_PROMPTED
-    ]
 
 
 class InteractionManager:

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/interaction_manager.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/interaction_manager.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 
+from controllers.vision_project_delegator import DatabaseKeys
 from interaction_engine.interfaces import TerminalClientAndServerInterface
 from interaction_engine.planner import MessagerPlanner
 from interaction_builder import InteractionBuilder
@@ -128,9 +129,9 @@ class InteractionManager:
         return self._planner
 
     def _set_vars_after_ask_to_do_scheduled(self):
-        if self._state_database.get("is off checkin") == "Yes":
-            self._state_database.set("is off checkin", None)
-            if self._state_database.get("video to play"):
+        if self._state_database.get(DatabaseKeys.IS_OFF_CHECKIN) == "Yes":
+            self._state_database.set(DatabaseKeys.IS_OFF_CHECKIN, None)
+            if self._state_database.get(DatabaseKeys.VIDEO_TO_PLAY):
                 self._planner.insert(
                     self._interaction_builder.interactions[InteractionBuilder.Graphs.FEEDBACK_VIDEO],
                 )
@@ -145,9 +146,9 @@ class InteractionManager:
             )
 
     def _set_vars_after_scheduled_ask_for_eval(self):
-        if self._state_database.get("is do evaluation") == "Yes":
-            self._state_database.set("is do evaluation", None)
-            if self._state_database.get("video to play"):
+        if self._state_database.get(DatabaseKeys.IS_DO_EVALUATION) == "Yes":
+            self._state_database.set(DatabaseKeys.IS_DO_EVALUATION, None)
+            if self._state_database.get(DatabaseKeys.VIDEO_TO_PLAY):
                 self._planner.insert(
                     self._interaction_builder.interactions[InteractionBuilder.Graphs.FEEDBACK_VIDEO],
                 )
@@ -161,8 +162,8 @@ class InteractionManager:
             )
 
     def _set_vars_after_prompted_ask_to_chat(self):
-        if self._state_database.get("good to chat") == "Yes":
-            self._state_database.set("good to chat", None)
+        if self._state_database.get(DatabaseKeys.GOOD_TO_CHAT) == "Yes":
+            self._state_database.set(DatabaseKeys.GOOD_TO_CHAT, None)
             self._planner.insert(
                 self._interaction_builder.interactions[InteractionBuilder.Graphs.PROMPTED_CHECKIN],
                 post_hook=self._set_vars_after_prompted
@@ -174,8 +175,8 @@ class InteractionManager:
             )
 
     def _set_vars_after_scheduled_ask_to_chat(self):
-        if self._state_database.get("good to chat") == "Yes":
-            self._state_database.set("good to chat", None)
+        if self._state_database.get(DatabaseKeys.GOOD_TO_CHAT) == "Yes":
+            self._state_database.set(DatabaseKeys.GOOD_TO_CHAT, None)
             self._planner.insert(
                 self._interaction_builder.interactions[InteractionBuilder.Graphs.SCHEDULED_CHECKIN],
             )
@@ -184,15 +185,15 @@ class InteractionManager:
                 post_hook=self._set_vars_after_scheduled_ask_for_eval
             )
         else:
-            self._state_database.set("good to chat", None)
+            self._state_database.set(DatabaseKeys.GOOD_TO_CHAT, None)
             self._planner.insert(
                 self._interaction_builder.interactions[InteractionBuilder.Graphs.PLAN_NEXT_CHECKIN],
                 post_hook=self._set_vars_after_interaction
             )
 
     def _set_vars_after_ask_to_do_perseverance(self):
-        if self._state_database.get("is start perseverance") == "Yes":
-            self._state_database.set("is start perseverance", None)
+        if self._state_database.get(DatabaseKeys.IS_START_PERSEVERANCE) == "Yes":
+            self._state_database.set(DatabaseKeys.IS_START_PERSEVERANCE, None)
             self._planner.insert(
                 plan=self._interaction_builder.interactions[InteractionBuilder.Graphs.PERSEVERANCE],
                 post_hook=self._set_vars_after_perseverance
@@ -214,32 +215,32 @@ class InteractionManager:
             )
 
     def _set_vars_after_evaluation(self):
-        self._state_database.set("is done eval today", True)
-        eval_index = self._state_database.get("reading eval index")
-        self._state_database.set("reading eval index", eval_index + 1)
+        self._state_database.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+        eval_index = self._state_database.get(DatabaseKeys.READING_EVAL_INDEX)
+        self._state_database.set(DatabaseKeys.READING_EVAL_INDEX, eval_index + 1)
         # also need to calculate and save reading speed
         self._set_vars_after_interaction()
 
     def _set_vars_after_interaction(self):
-        self._state_database.set("is prompted by user", False)
-        self._state_database.set("is interaction finished", True)
-        self._state_database.set("last interaction datetime", datetime.datetime.now())
+        self._state_database.set(DatabaseKeys.IS_PROMPTED_BY_USER, False)
+        self._state_database.set(DatabaseKeys.IS_INTERACTION_FINISHED, True)
+        self._state_database.set(DatabaseKeys.LAST_INTERACTION_DATETIME, datetime.datetime.now())
 
     def _set_vars_after_first_interaction(self):
-        self._state_database.set("first interaction datetime", datetime.datetime.now())
+        self._state_database.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime.now())
         self._set_vars_after_interaction()
 
     def _set_vars_after_goal_setting(self):
-        self._state_database.set("num of days since last goal setting", 0)
+        self._state_database.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING, 0)
         self._set_vars_after_interaction()
 
     def _set_vars_after_mindfulness(self):
-        self._state_database.set("num of days since last _set_vars_after_mindfulness", 0)
+        self._state_database.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS, 0)
         self._set_vars_after_interaction()
 
     def _set_vars_after_perseverance(self):
-        perseverance_counter = self._state_database.get("perseverance counter") + 1
-        self._state_database.set("perseverance counter", perseverance_counter)
+        perseverance_counter = self._state_database.get(DatabaseKeys.PERSEVERANCE_COUNTER) + 1
+        self._state_database.set(DatabaseKeys.PERSEVERANCE_COUNTER, perseverance_counter)
         if perseverance_counter >= self._max_num_of_perseverance_readings:
             self._planner.insert(
                 plan=self._interaction_builder.interactions[InteractionBuilder.Graphs.REWARD]
@@ -254,7 +255,7 @@ class InteractionManager:
             )
 
     def _set_vars_after_continue_perseverance(self):
-        if self._state_database.get("is continue perseverance") == "Continue":
+        if self._state_database.get(DatabaseKeys.IS_CONTINUE_PERSEVERANCE) == "Continue":
             self._planner.insert(
                 plan=self._interaction_builder.interactions[InteractionBuilder.Graphs.PERSEVERANCE],
                 post_hook=self._set_vars_after_perseverance
@@ -269,46 +270,46 @@ class InteractionManager:
             )
 
     def _set_vars_after_prompted(self):
-        num_of_prompted_today = self._state_database.get("num of prompted today") + 1
-        self._state_database.set("num of prompted today", num_of_prompted_today)
-        self._state_database.set("is prompted by user", False)
-        self._state_database.set("is done prompted today", True)
+        num_of_prompted_today = self._state_database.get(DatabaseKeys.NUM_OF_PROMPTED_TODAY) + 1
+        self._state_database.set(DatabaseKeys.NUM_OF_PROMPTED_TODAY, num_of_prompted_today)
+        self._state_database.set(DatabaseKeys.IS_PROMPTED_BY_USER, False)
+        self._state_database.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
         self._set_vars_after_interaction()
 
     def _set_vars_after_too_many_prompted(self):
         self._set_vars_after_interaction()
-        self._state_database.set("is prompted by user", False)
+        self._state_database.set(DatabaseKeys.IS_PROMPTED_BY_USER, False)
 
     def _is_do_mindfulness(self):
-        last_5_scores = self._state_database.get("last 5 eval scores")
+        last_5_scores = self._state_database.get(DatabaseKeys.LAST_5_EVAL_SCORES)
         if len(last_5_scores) > 0:
             average_eval_score = sum(last_5_scores) / len(last_5_scores)
         else:
             average_eval_score = 0
         return self._days_since_first_interaction() >= 7 \
-            and self._state_database.get("feelings index") <= 3 \
-            and self._state_database.get("current eval score") < average_eval_score
+            and self._state_database.get(DatabaseKeys.FEELINGS_INDEX) <= 3 \
+            and self._state_database.get(DatabaseKeys.CURRENT_EVAL_SCORE) < average_eval_score
 
     def _is_do_goal_setting(self):
-        last_5_scores = self._state_database.get("last 5 eval scores")
+        last_5_scores = self._state_database.get(DatabaseKeys.LAST_5_EVAL_SCORES)
         if len(last_5_scores) > 0:
             average_eval_score = sum(last_5_scores)/len(last_5_scores)
         else:
             average_eval_score = 0
         return self._days_since_first_interaction() >= 7 \
-            and self._state_database.get("feelings index") <= 3 \
-            and self._state_database.get("num of days since last goal setting") >= 7 \
-            and self._state_database.get("num of days since last prompt") >= self._num_of_days_to_prompt_goal_setting \
-            and self._state_database.get("num of days since last perseverance") >= self._num_of_days_to_prompt_goal_setting \
-            and self._state_database.get("current eval score") < average_eval_score
+            and self._state_database.get(DatabaseKeys.FEELINGS_INDEX) <= 3 \
+            and self._state_database.get(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING) >= 7 \
+            and self._state_database.get(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT) >= self._num_of_days_to_prompt_goal_setting \
+            and self._state_database.get(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE) >= self._num_of_days_to_prompt_goal_setting \
+            and self._state_database.get(DatabaseKeys.CURRENT_EVAL_SCORE) < average_eval_score
 
     def _days_since_first_interaction(self):
-        first_interaction_datetime = self._state_database.get("first interaction datetime")
+        first_interaction_datetime = self._state_database.get(DatabaseKeys.FIRST_INTERACTION_DATETIME)
         if first_interaction_datetime is None:
             num_of_days = 0
         else:
             current_date = datetime.datetime.now().date()
-            num_of_days = (current_date - self._state_database.get("first interaction datetime").date()).days
+            num_of_days = (current_date - self._state_database.get(DatabaseKeys.FIRST_INTERACTION_DATETIME).date()).days
         return num_of_days
 
     @property

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
@@ -74,12 +74,12 @@ class VisionProjectDelegator:
         last_5_scores = self._state_database.get(DatabaseKeys.LAST_5_EVAL_SCORES)
         average_score = sum(last_5_scores)/len(last_5_scores)
         last_score = self._state_database.get(DatabaseKeys.LAST_SCORE)
-        if average_score - self._score_window <= last_score <= average_score + self._score_window:
-            self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 0)  # STABLE
-        elif last_score < average_score - self._score_window:
+        if last_score < average_score - self._score_window:
             self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 1)  # DECLINED
-        else:
+        elif last_score > average_score + self._score_window:
             self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 2)  # IMPROVED
+        else:
+            self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 0)  # STABLE
 
     def get_interaction_type(self):
         logging.info("Determining interaction type")

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
@@ -7,54 +7,99 @@ from controllers.interaction_manager import Interactions
 
 logging.basicConfig(level=logging.INFO)
 
+
+class DatabaseKeys:
+    BEST_SCORE = "best score"
+    CURRENT_EVAL_SCORE = "current eval score"
+    CURRENT_READING_COLOR = "current reading color"
+    CURRENT_READING_ID = "current reading id"
+    DIFFICULTY_LEVEL = "difficulty level"
+    FEEDBACK_VIDEOS = "feedback videos"
+    FIRST_INTERACTION_DATETIME = "first interaction datetime"
+    GOOD_TO_CHAT = "good to chat"
+    GRIT_FEEDBACK_INDEX = "grit feedback index"
+    IS_CONTINUE_PERSEVERANCE = "is continue perseverance"
+    IS_DO_EVALUATION = "is do evaluation"
+    IS_DONE_EVAL_TODAY = "is done eval today"
+    IS_DONE_GOAL_SETTING_TODAY = "is done goal setting today"
+    IS_DONE_MINDFULNESS_TODAY = "is done mindfulness today"
+    IS_DONE_PERSEVERANCE_TODAY = "is done perseverance today"
+    IS_DONE_PROMPTED_TODAY = "is done prompted today"
+    IS_INTERACTION_FINISHED = "is interaction finished"
+    IS_NEW_DIFFICULTY_LEVEL = "is new difficulty level"
+    IS_OFF_CHECKIN = "is off checkin"
+    IS_PROMPTED_BY_USER = "is prompted by user"
+    IS_PUBLISHED_CHOICES_TODAY = "is published choices today"
+    IS_START_PERSEVERANCE = "is start perseverance"
+    IS_USED_MAGNIFIER_TODAY = "is used magnifier today"
+    LAST_5_EVAL_SCORES = "last 5 eval scores"
+    LAST_INTERACTION_DATETIME = "last interaction datetime"
+    LAST_UPDATE_DATETIME = "last update datetime"
+    LAST_SCORE = "last score"
+    FEELINGS_INDEX = "feelings index"
+    NEXT_CHECKIN_DATETIME = "next checkin datetime"
+    NUM_OF_DAYS_SINCE_LAST_EVAL = "num of days since last eval"
+    NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING = "num of days since last goal setting"
+    NUM_OF_DAYS_SINCE_LAST_MINDFULNESS = "num of days since last mindfulness"
+    NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE = "num of days since last perseverance"
+    NUM_OF_DAYS_SINCE_LAST_PROMPT = "num of days since last prompt"
+    NUM_OF_PROMPTED_TODAY = "num of prompted today"
+    PERSEVERANCE_COUNTER = "perseverance counter"
+    READING_EVAL_DATA = "reading eval data"
+    READING_EVAL_INDEX = "reading eval index"
+    READING_EVAL_TYPE = "reading eval type"
+    USER_NAME = "user name"
+    VIDEO_TO_PLAY = "video to play"
+
+
 INITIAL_STATE_DB = {
-    "best score": None,
-    "current eval score": 0,
-    "current reading color": None,
-    "current reading id": None,
-    "difficulty level": 1,
-    "feedback videos": {
+    DatabaseKeys.BEST_SCORE: None,
+    DatabaseKeys.CURRENT_EVAL_SCORE: 0,
+    DatabaseKeys.CURRENT_READING_COLOR: None,
+    DatabaseKeys.CURRENT_READING_ID: None,
+    DatabaseKeys.DIFFICULTY_LEVEL: 1,
+    DatabaseKeys.FEEDBACK_VIDEOS: {
         "video 1": "https://www.youtube.com/embed/4b33NTAuF5E",
         "video 2": "https://www.youtube.com/embed/JXeJANDKwDc",
         "video 3": "https://www.youtube.com/embed/uzkD5SeuwzM",
         "video 4": "https://www.youtube.com/embed/QqsLTNkzvaY",
         "no video": ""
     },
-    "first interaction datetime": None,
-    "good to chat": None,
-    "grit feedback index": 0,
-    "is continue perseverance": None,
-    "is do evaluation": None,
-    "is done eval today": False,
-    "is done prompted today": False,
-    "is done perseverance today": False,
-    "is done mindfulness today": False,
-    "is done goal setting today": False,
-    "is interaction finished": False,
-    "is new difficulty level": False,
-    "is off checkin": None,
-    "is prompted by user": False,
-    "is published choices today": False,
-    "is start perseverance": False,
-    "is used magnifier today": False,
-    "last 5 eval scores": [],
-    "last interaction datetime": None,
-    "last update datetime": None,
-    "last score": None,
-    "feelings index": None,
-    "next checkin datetime": None,
-    "num of days since last eval": 0,
-    "num of days since last prompt": 0,
-    "num of days since last perseverance": 0,
-    "num of days since last mindfulness": 0,
-    "num of days since last goal setting": 0,
-    "num of prompted today": 0,
-    "perseverance counter": 0,
-    "reading eval index": 0,
-    "reading eval data": [],
-    "reading eval type": None,
-    "user name": "",
-    "video to play": None
+    DatabaseKeys.FIRST_INTERACTION_DATETIME: None,
+    DatabaseKeys.GOOD_TO_CHAT: None,
+    DatabaseKeys.GRIT_FEEDBACK_INDEX: 0,
+    DatabaseKeys.IS_CONTINUE_PERSEVERANCE: None,
+    DatabaseKeys.IS_DO_EVALUATION: None,
+    DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+    DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+    DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+    DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+    DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+    DatabaseKeys.IS_INTERACTION_FINISHED: False,
+    DatabaseKeys.IS_NEW_DIFFICULTY_LEVEL: False,
+    DatabaseKeys.IS_OFF_CHECKIN: None,
+    DatabaseKeys.IS_PROMPTED_BY_USER: False,
+    DatabaseKeys.IS_PUBLISHED_CHOICES_TODAY: False,
+    DatabaseKeys.IS_START_PERSEVERANCE: False,
+    DatabaseKeys.IS_USED_MAGNIFIER_TODAY: False,
+    DatabaseKeys.LAST_5_EVAL_SCORES: [],
+    DatabaseKeys.LAST_INTERACTION_DATETIME: None,
+    DatabaseKeys.LAST_UPDATE_DATETIME: None,
+    DatabaseKeys.LAST_SCORE: None,
+    DatabaseKeys.FEELINGS_INDEX: None,
+    DatabaseKeys.NEXT_CHECKIN_DATETIME: None,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+    DatabaseKeys.NUM_OF_PROMPTED_TODAY: 0,
+    DatabaseKeys.PERSEVERANCE_COUNTER: 0,
+    DatabaseKeys.READING_EVAL_DATA: [],
+    DatabaseKeys.READING_EVAL_INDEX: 0,
+    DatabaseKeys.READING_EVAL_TYPE: None,
+    DatabaseKeys.USER_NAME: "",
+    DatabaseKeys.VIDEO_TO_PLAY: None
 }
 
 

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
@@ -133,20 +133,19 @@ class VisionProjectDelegator:
             self._state_database.set("grit feedback index", 2)  # IMPROVED
 
     def get_interaction_type(self):
-        # logging.info("Determining interaction type")
-        # if self._is_first_interaction():
-        #     interaction_type = Interactions.FIRST_INTERACTION
-        # elif self._is_time_for_scheduled_interaction():
-        #     interaction_type = Interactions.SCHEDULED_INTERACTION
-        # elif self._is_run_too_many_prompted():
-        #     interaction_type = Interactions.TOO_MANY_PROMPTED
-        # elif self._is_run_prompted_interaction():
-        #     interaction_type = Interactions.PROMPTED_INTERACTION
-        # elif self._is_ask_to_do_scheduled():
-        #     interaction_type = Interactions.ASK_TO_DO_SCHEDULED
-        # else:
-        #     interaction_type = None
-        interaction_type = Interactions.SCHEDULED_INTERACTION
+        logging.info("Determining interaction type")
+        if self._is_first_interaction():
+            interaction_type = Interactions.FIRST_INTERACTION
+        elif self._is_time_for_scheduled_interaction():
+            interaction_type = Interactions.SCHEDULED_INTERACTION
+        elif self._is_run_too_many_prompted():
+            interaction_type = Interactions.TOO_MANY_PROMPTED
+        elif self._is_run_prompted_interaction():
+            interaction_type = Interactions.PROMPTED_INTERACTION
+        elif self._is_ask_to_do_scheduled():
+            interaction_type = Interactions.ASK_TO_DO_SCHEDULED
+        else:
+            interaction_type = None
         return interaction_type
 
     def _is_first_interaction(self):

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
@@ -126,30 +126,30 @@ class VisionProjectDelegator:
         # for testing purposes
         self._reset_database()
 
-        self._state_database.set("last update datetime", datetime.datetime.now())
+        self._state_database.set(DatabaseKeys.LAST_UPDATE_DATETIME, datetime.datetime.now())
 
     def update(self):
-        if not self._state_database.is_set("last update datetime"):
-            self._state_database.set("last update datetime", datetime.datetime.now())
+        if not self._state_database.is_set(DatabaseKeys.LAST_UPDATE_DATETIME):
+            self._state_database.set(DatabaseKeys.LAST_UPDATE_DATETIME, datetime.datetime.now())
         if self._is_new_day():
             self._daily_state_update()
             self._update_act_variables()
-            self._state_database.set("num of prompted today", 0)
-            self._state_database.set("perseverance counter", 0)
-            self._state_database.set("feelings index", None)
-            self._state_database.set("is published choices today", False)
-        self._state_database.set("last update datetime", datetime.datetime.now())
+            self._state_database.set(DatabaseKeys.NUM_OF_PROMPTED_TODAY, 0)
+            self._state_database.set(DatabaseKeys.PERSEVERANCE_COUNTER, 0)
+            self._state_database.set(DatabaseKeys.FEELINGS_INDEX, None)
+            self._state_database.set(DatabaseKeys.IS_PUBLISHED_CHOICES_TODAY, False)
+        self._state_database.set(DatabaseKeys.LAST_UPDATE_DATETIME, datetime.datetime.now())
 
     def _is_new_day(self):
-        return datetime.datetime.now().date() > self._state_database.get("last update datetime").date()
+        return datetime.datetime.now().date() > self._state_database.get(DatabaseKeys.LAST_UPDATE_DATETIME).date()
 
     def _daily_state_update(self):
         keys_to_check = {
-            "is done eval today": "num of days since last eval",
-            "is done prompted today": "num of days since last prompt",
-            "is done perseverance today": "num of days since last perseverance",
-            "is done mindfulness today": "num of days since last mindfulness",
-            "is done goal setting today": "num of days since last goal setting"
+            DatabaseKeys.IS_DONE_EVAL_TODAY: DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL,
+            DatabaseKeys.IS_DONE_PROMPTED_TODAY: DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT,
+            DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE,
+            DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS,
+            DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING
         }
         for key in keys_to_check:
             if not self._state_database.get(key):
@@ -160,22 +160,22 @@ class VisionProjectDelegator:
             self._state_database.set(key, False)
 
     def _update_act_variables(self):
-        last_5_scores = self._state_database.get("last 5 eval scores")
+        last_5_scores = self._state_database.get(DatabaseKeys.LAST_5_EVAL_SCORES)
         if len(last_5_scores) == 5:
             last_5_scores.pop(0)
-        last_5_scores.append(self._state_database.get("current eval score"))
-        self._state_database.set("last 5 eval scores", last_5_scores)
+        last_5_scores.append(self._state_database.get(DatabaseKeys.CURRENT_EVAL_SCORE))
+        self._state_database.set(DatabaseKeys.LAST_5_EVAL_SCORES, last_5_scores)
 
     def _update_reading_task_data(self):
-        last_5_scores = self._state_database.get("last 5 eval scores")
+        last_5_scores = self._state_database.get(DatabaseKeys.LAST_5_EVAL_SCORES)
         average_score = sum(last_5_scores)/len(last_5_scores)
-        last_score = self._state_database.get("last score")
+        last_score = self._state_database.get(DatabaseKeys.LAST_SCORE)
         if average_score - self._score_window <= last_score <= average_score + self._score_window:
-            self._state_database.set("grit feedback index", 0)  # STABLE
+            self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 0)  # STABLE
         elif last_score < average_score - self._score_window:
-            self._state_database.set("grit feedback index", 1)  # DECLINED
+            self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 1)  # DECLINED
         else:
-            self._state_database.set("grit feedback index", 2)  # IMPROVED
+            self._state_database.set(DatabaseKeys.GRIT_FEEDBACK_INDEX, 2)  # IMPROVED
 
     def get_interaction_type(self):
         logging.info("Determining interaction type")
@@ -194,50 +194,50 @@ class VisionProjectDelegator:
         return interaction_type
 
     def _is_first_interaction(self):
-        return not self._state_database.is_set("first interaction datetime")
+        return not self._state_database.is_set(DatabaseKeys.FIRST_INTERACTION_DATETIME)
 
     def _is_time_for_scheduled_interaction(self):
-        if not self._state_database.get("next checkin datetime"):
+        if not self._state_database.get(DatabaseKeys.NEXT_CHECKIN_DATETIME):
             return False
 
-        if self._state_database.get("is done eval today"):
+        if self._state_database.get(DatabaseKeys.IS_DONE_EVAL_TODAY):
             is_time = False
         else:
             is_in_update_window = self._is_in_window(
-                self._state_database.get("next checkin datetime"),
+                self._state_database.get(DatabaseKeys.NEXT_CHECKIN_DATETIME),
                 self._update_window_seconds,
                 datetime.datetime.now()
             )
             is_prompted_in_scheduled_window = self._is_in_window(
-                self._state_database.get("next checkin datetime"),
+                self._state_database.get(DatabaseKeys.NEXT_CHECKIN_DATETIME),
                 self._scheduled_window_minutes,
                 datetime.datetime.now()
             )
 
             is_time = is_in_update_window or \
-                      (is_prompted_in_scheduled_window and not self._state_database.get("is done eval today") and
-                       self._state_database.get("is prompted by user"))
+                      (is_prompted_in_scheduled_window and not self._state_database.get(DatabaseKeys.IS_DONE_EVAL_TODAY) and
+                       self._state_database.get(DatabaseKeys.IS_PROMPTED_BY_USER))
 
         return is_time
 
     def _is_ask_to_do_scheduled(self):
         is_in_scheduled_window = self._is_in_window(
-            self._state_database.get("next checkin datetime"),
+            self._state_database.get(DatabaseKeys.NEXT_CHECKIN_DATETIME),
             self._scheduled_window_minutes,
             datetime.datetime.now()
         )
-        return self._state_database.get("is prompted by user") and \
-            not self._state_database.get("is done eval today") and \
+        return self._state_database.get(DatabaseKeys.IS_PROMPTED_BY_USER) and \
+            not self._state_database.get(DatabaseKeys.IS_DONE_EVAL_TODAY) and \
             not is_in_scheduled_window
 
     def _is_run_prompted_interaction(self):
-        return self._state_database.get("is prompted by user") and \
-            self._state_database.get("is done eval today") and \
-            self._state_database.get("num of prompted today") < self._max_num_of_prompted_per_day
+        return self._state_database.get(DatabaseKeys.IS_PROMPTED_BY_USER) and \
+            self._state_database.get(DatabaseKeys.IS_DONE_EVAL_TODAY) and \
+            self._state_database.get(DatabaseKeys.NUM_OF_PROMPTED_TODAY) < self._max_num_of_prompted_per_day
 
     def _is_run_too_many_prompted(self):
-        return self._state_database.get("is prompted by user") and \
-               self._state_database.get("num of prompted today") >= self._max_num_of_prompted_per_day
+        return self._state_database.get(DatabaseKeys.IS_PROMPTED_BY_USER) and \
+               self._state_database.get(DatabaseKeys.NUM_OF_PROMPTED_TODAY) >= self._max_num_of_prompted_per_day
 
     def _is_in_window(self, center, window, time_to_check):
         start_time = center - window

--- a/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/controllers/vision_project_delegator.py
@@ -1,106 +1,10 @@
 #!/usr/bin/env python3.8
 import datetime
 import logging
-import math
 
-from controllers.interaction_manager import Interactions
+from vision_project_tools.constants import DatabaseKeys, INITIAL_STATE_DB, Interactions
 
 logging.basicConfig(level=logging.INFO)
-
-
-class DatabaseKeys:
-    BEST_SCORE = "best score"
-    CURRENT_EVAL_SCORE = "current eval score"
-    CURRENT_READING_COLOR = "current reading color"
-    CURRENT_READING_ID = "current reading id"
-    DIFFICULTY_LEVEL = "difficulty level"
-    FEEDBACK_VIDEOS = "feedback videos"
-    FIRST_INTERACTION_DATETIME = "first interaction datetime"
-    GOOD_TO_CHAT = "good to chat"
-    GRIT_FEEDBACK_INDEX = "grit feedback index"
-    IS_CONTINUE_PERSEVERANCE = "is continue perseverance"
-    IS_DO_EVALUATION = "is do evaluation"
-    IS_DONE_EVAL_TODAY = "is done eval today"
-    IS_DONE_GOAL_SETTING_TODAY = "is done goal setting today"
-    IS_DONE_MINDFULNESS_TODAY = "is done mindfulness today"
-    IS_DONE_PERSEVERANCE_TODAY = "is done perseverance today"
-    IS_DONE_PROMPTED_TODAY = "is done prompted today"
-    IS_INTERACTION_FINISHED = "is interaction finished"
-    IS_NEW_DIFFICULTY_LEVEL = "is new difficulty level"
-    IS_OFF_CHECKIN = "is off checkin"
-    IS_PROMPTED_BY_USER = "is prompted by user"
-    IS_PUBLISHED_CHOICES_TODAY = "is published choices today"
-    IS_START_PERSEVERANCE = "is start perseverance"
-    IS_USED_MAGNIFIER_TODAY = "is used magnifier today"
-    LAST_5_EVAL_SCORES = "last 5 eval scores"
-    LAST_INTERACTION_DATETIME = "last interaction datetime"
-    LAST_UPDATE_DATETIME = "last update datetime"
-    LAST_SCORE = "last score"
-    FEELINGS_INDEX = "feelings index"
-    NEXT_CHECKIN_DATETIME = "next checkin datetime"
-    NUM_OF_DAYS_SINCE_LAST_EVAL = "num of days since last eval"
-    NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING = "num of days since last goal setting"
-    NUM_OF_DAYS_SINCE_LAST_MINDFULNESS = "num of days since last mindfulness"
-    NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE = "num of days since last perseverance"
-    NUM_OF_DAYS_SINCE_LAST_PROMPT = "num of days since last prompt"
-    NUM_OF_PROMPTED_TODAY = "num of prompted today"
-    PERSEVERANCE_COUNTER = "perseverance counter"
-    READING_EVAL_DATA = "reading eval data"
-    READING_EVAL_INDEX = "reading eval index"
-    READING_EVAL_TYPE = "reading eval type"
-    USER_NAME = "user name"
-    VIDEO_TO_PLAY = "video to play"
-
-
-INITIAL_STATE_DB = {
-    DatabaseKeys.BEST_SCORE: None,
-    DatabaseKeys.CURRENT_EVAL_SCORE: 0,
-    DatabaseKeys.CURRENT_READING_COLOR: None,
-    DatabaseKeys.CURRENT_READING_ID: None,
-    DatabaseKeys.DIFFICULTY_LEVEL: 1,
-    DatabaseKeys.FEEDBACK_VIDEOS: {
-        "video 1": "https://www.youtube.com/embed/4b33NTAuF5E",
-        "video 2": "https://www.youtube.com/embed/JXeJANDKwDc",
-        "video 3": "https://www.youtube.com/embed/uzkD5SeuwzM",
-        "video 4": "https://www.youtube.com/embed/QqsLTNkzvaY",
-        "no video": ""
-    },
-    DatabaseKeys.FIRST_INTERACTION_DATETIME: None,
-    DatabaseKeys.GOOD_TO_CHAT: None,
-    DatabaseKeys.GRIT_FEEDBACK_INDEX: 0,
-    DatabaseKeys.IS_CONTINUE_PERSEVERANCE: None,
-    DatabaseKeys.IS_DO_EVALUATION: None,
-    DatabaseKeys.IS_DONE_EVAL_TODAY: False,
-    DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
-    DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
-    DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
-    DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
-    DatabaseKeys.IS_INTERACTION_FINISHED: False,
-    DatabaseKeys.IS_NEW_DIFFICULTY_LEVEL: False,
-    DatabaseKeys.IS_OFF_CHECKIN: None,
-    DatabaseKeys.IS_PROMPTED_BY_USER: False,
-    DatabaseKeys.IS_PUBLISHED_CHOICES_TODAY: False,
-    DatabaseKeys.IS_START_PERSEVERANCE: False,
-    DatabaseKeys.IS_USED_MAGNIFIER_TODAY: False,
-    DatabaseKeys.LAST_5_EVAL_SCORES: [],
-    DatabaseKeys.LAST_INTERACTION_DATETIME: None,
-    DatabaseKeys.LAST_UPDATE_DATETIME: None,
-    DatabaseKeys.LAST_SCORE: None,
-    DatabaseKeys.FEELINGS_INDEX: None,
-    DatabaseKeys.NEXT_CHECKIN_DATETIME: None,
-    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
-    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
-    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
-    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
-    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
-    DatabaseKeys.NUM_OF_PROMPTED_TODAY: 0,
-    DatabaseKeys.PERSEVERANCE_COUNTER: 0,
-    DatabaseKeys.READING_EVAL_DATA: [],
-    DatabaseKeys.READING_EVAL_INDEX: 0,
-    DatabaseKeys.READING_EVAL_TYPE: None,
-    DatabaseKeys.USER_NAME: "",
-    DatabaseKeys.VIDEO_TO_PLAY: None
-}
 
 
 class VisionProjectDelegator:

--- a/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
+++ b/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3.8
+import collections
+import contextlib
+import logging
+import speech_recognition
+import wave
+import webrtcvad
+
+from pydub import AudioSegment
+
+logging.basicConfig(level=logging.INFO)
+
+
+class Frame(object):
+    """Represents a "frame" of audio data."""
+
+    def __init__(self, bytes, timestamp, duration):
+        self.bytes = bytes
+        self.timestamp = timestamp
+        self.duration = duration
+
+
+class ReadingEvaluator:
+    """Finds and """
+
+    def __init__(
+            self,
+            silence_threshold=-35,
+            sample_rate=16000,
+            chunk_size=10,
+    ):
+        self._silence_threshold = silence_threshold
+        self._sample_rate = sample_rate
+        self._chunk_size = chunk_size
+
+        self._sr = speech_recognition.Recognizer()
+        self._vad = webrtcvad.Vad()
+        self._vad.set_mode(3)
+
+    def get_total_speaking_time(self, audio_file_path):
+        total_speaking_time = 0.0
+        audio, sample_rate = self.read_wav(audio_file_path)
+        frame_duration_ms = 30
+        padding_duration_ms = 300
+        frames = list(self.generate_frames(frame_duration_ms, audio, sample_rate))
+        voiced_segments = self.get_voiced_audio_from_frames(
+            sample_rate,
+            frame_duration_ms,
+            padding_duration_ms,
+            frames
+        )
+        for segment in voiced_segments:
+            audio_segment = AudioSegment(segment, sample_width=2, frame_rate=sample_rate, channels=1)
+            total_speaking_time += audio_segment.duration_seconds
+        return total_speaking_time
+
+    def read_wav(self, path):
+        """Reads a .wav file.
+        Takes the path, and returns (PCM audio data, sample rate).
+        """
+        with contextlib.closing(wave.open(path, 'rb')) as wf:
+            num_channels = wf.getnchannels()
+            if num_channels != 1:
+                raise ValueError("Invalid number of channels")
+            sample_width = wf.getsampwidth()
+            if sample_width != 2:
+                raise ValueError("Invalid sample width")
+            sample_rate = wf.getframerate()
+            if sample_rate not in (8000, 16000, 32000, 48000):
+                raise ValueError("Invalid sample rate")
+            pcm_data = wf.readframes(wf.getnframes())
+            return pcm_data, sample_rate
+
+    def generate_frames(self, frame_duration_ms, audio, sample_rate):
+        """Generates audio frames from PCM audio data.
+        Takes the desired frame duration in milliseconds, the PCM data, and
+        the sample rate.
+        Yields Frames of the requested duration.
+        """
+        n = int(sample_rate * (frame_duration_ms / 1000.0) * 2)
+        offset = 0
+        timestamp = 0.0
+        duration = (float(n) / sample_rate) / 2.0
+        while offset + n < len(audio):
+            yield Frame(audio[offset:offset + n], timestamp, duration)
+            timestamp += duration
+            offset += n
+
+    def get_voiced_audio_from_frames(
+            self,
+            sample_rate,
+            frame_duration_ms,
+            padding_duration_ms,
+            frames
+    ):
+        """Filters out non-voices audio frames and yields the resulting voices audio data in bytes."""
+        num_padding_frames = int(padding_duration_ms / frame_duration_ms)
+        ring_buffer = collections.deque(maxlen=num_padding_frames)
+        triggered = False
+
+        voiced_frames = []
+        for frame in frames:
+            is_speech = self._vad.is_speech(frame.bytes, sample_rate)
+
+            if not triggered:
+                ring_buffer.append((frame, is_speech))
+                num_voiced = len([f for f, speech in ring_buffer if speech])
+                if num_voiced > 0.9 * ring_buffer.maxlen:
+                    triggered = True
+                    for f, s in ring_buffer:
+                        voiced_frames.append(f)
+                    ring_buffer.clear()
+            else:
+                voiced_frames.append(frame)
+                ring_buffer.append((frame, is_speech))
+                num_unvoiced = len([f for f, speech in ring_buffer if not speech])
+                if num_unvoiced > 0.9 * ring_buffer.maxlen:
+                    triggered = False
+                    yield b''.join([f.bytes for f in voiced_frames])
+                    ring_buffer.clear()
+                    voiced_frames = []
+        # Yield any leftover frames
+        if voiced_frames:
+            yield b''.join([f.bytes for f in voiced_frames])

--- a/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
+++ b/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
@@ -21,7 +21,7 @@ class Frame(object):
 
 
 class ReadingEvaluator:
-    """Finds and """
+    """Computes total speaking time in a given audio file."""
 
     def __init__(
             self,
@@ -122,3 +122,11 @@ class ReadingEvaluator:
         # Yield any leftover frames
         if voiced_frames:
             yield b''.join([f.bytes for f in voiced_frames])
+
+
+if __name__ == "__main__":
+    import os
+
+    evaluator = ReadingEvaluator()
+    audio_file_path = os.path.join("/root", "catkin_ws", "src", "test.wav")
+    print(evaluator.get_total_speaking_time(audio_file_path))

--- a/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
+++ b/src/ros_vision_interaction/src/vision-interaction/reading_evaluator/__init__.py
@@ -2,7 +2,6 @@
 import collections
 import contextlib
 import logging
-import speech_recognition
 import wave
 import webrtcvad
 
@@ -23,21 +22,12 @@ class Frame(object):
 class ReadingEvaluator:
     """Computes total speaking time in a given audio file."""
 
-    def __init__(
-            self,
-            silence_threshold=-35,
-            sample_rate=16000,
-            chunk_size=10,
-    ):
-        self._silence_threshold = silence_threshold
-        self._sample_rate = sample_rate
-        self._chunk_size = chunk_size
-
-        self._sr = speech_recognition.Recognizer()
+    def __init__(self,):
         self._vad = webrtcvad.Vad()
         self._vad.set_mode(3)
 
     def get_total_speaking_time(self, audio_file_path):
+        """Reads a .wav file and returns the total length of speaking time (float)."""
         total_speaking_time = 0.0
         audio, sample_rate = self.read_wav(audio_file_path)
         frame_duration_ms = 30

--- a/src/ros_vision_interaction/src/vision-interaction/tests/conftest.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/conftest.py
@@ -5,8 +5,8 @@ import mongomock
 import os
 import pytest
 
-from controllers.vision_project_delegator import INITIAL_STATE_DB
 from interaction_builder import InteractionBuilder
+from vision_project_tools.constants import INITIAL_STATE_DB
 from vision_project_tools.engine_statedb import EngineStateDb as StateDb
 
 DATABASE_NAME = 'vision_project'

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_builder.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_builder.py
@@ -1,6 +1,4 @@
-import mock
-import pytest
-
+#!/usr/bin/python3.8
 
 def test_build_graph_from_json(interaction_builder):
     test_graph_dict = {

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_manager.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_manager.py
@@ -4,6 +4,8 @@ import freezegun
 import pytest
 
 from controllers import InteractionManager
+from controllers.interaction_manager import Interactions
+from controllers.vision_project_delegator import DatabaseKeys
 from vision_project_tools.vision_engine import VisionInteractionEngine as InteractionEngine
 
 
@@ -34,72 +36,72 @@ def interaction_manager(statedb, interaction_builder, monkeypatch):
 
 
 def test_run_first_interaction(interaction_manager, statedb):
-    assert not interaction_manager._state_database.is_set("first interaction")
-    interaction_manager.run_interaction_once("first interaction")
-    assert interaction_manager._state_database.is_set("first interaction datetime")
+    assert not interaction_manager._state_database.is_set(DatabaseKeys.FIRST_INTERACTION_DATETIME)
+    interaction_manager.run_interaction_once(Interactions.FIRST_INTERACTION)
+    assert interaction_manager._state_database.is_set(DatabaseKeys.FIRST_INTERACTION_DATETIME)
 
 
 def test_run_scheduled_interaction(interaction_manager, statedb):
     with freezegun.freeze_time("2021-02-10"):
-        assert not statedb.is_set("last interaction time")
-        interaction_manager.run_interaction_once("scheduled interaction")
-        assert statedb.is_set("is done eval today")
+        assert not statedb.is_set(DatabaseKeys.LAST_INTERACTION_DATETIME)
+        interaction_manager.run_interaction_once(Interactions.SCHEDULED_INTERACTION)
+        assert statedb.is_set(DatabaseKeys.IS_DONE_EVAL_TODAY)
 
 
 def test_run_reading_evaluation(interaction_manager, statedb):
-    current_eval_index = statedb.get("reading eval index")
-    statedb.set("good to chat", "Yes")
-    statedb.set("is do evaluation", "Yes")
-    interaction_manager.run_interaction_once("scheduled interaction")
-    assert statedb.is_set("is done eval today")
-    assert statedb.get("is interaction finished")
-    assert statedb.get("reading eval index") == current_eval_index + 1
+    current_eval_index = statedb.get(DatabaseKeys.READING_EVAL_INDEX)
+    statedb.set(DatabaseKeys.GOOD_TO_CHAT, "Yes")
+    statedb.set(DatabaseKeys.IS_DO_EVALUATION, "Yes")
+    interaction_manager.run_interaction_once(Interactions.SCHEDULED_INTERACTION)
+    assert statedb.is_set(DatabaseKeys.IS_DONE_EVAL_TODAY)
+    assert statedb.get(DatabaseKeys.IS_INTERACTION_FINISHED)
+    assert statedb.get(DatabaseKeys.READING_EVAL_INDEX) == current_eval_index + 1
 
 
 def test_run_prompted_interaction(interaction_manager, statedb):
     with freezegun.freeze_time("2021-02-10"):
-        statedb.set("good to chat", "Yes")
-        assert statedb.get("num of prompted today") == 0
-        interaction_manager.run_interaction_once("prompted interaction")
-        assert statedb.get("num of prompted today") == 1
+        statedb.set(DatabaseKeys.GOOD_TO_CHAT, "Yes")
+        assert statedb.get(DatabaseKeys.NUM_OF_PROMPTED_TODAY) == 0
+        interaction_manager.run_interaction_once(Interactions.PROMPTED_INTERACTION)
+        assert statedb.get(DatabaseKeys.NUM_OF_PROMPTED_TODAY) == 1
 
 
 def test_determine_is_do_goal_setting(interaction_manager, statedb):
     # less than a week after first interaction
     first_interaction_datetime = datetime.datetime(2021, 4, 1, 12, 0, 0)
-    statedb.set("first interaction datetime", first_interaction_datetime)
-    statedb.set("feelings index", 2)
-    statedb.set("num of days since last prompt", 3)
-    statedb.set("num of days since last perseverance", 3)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
+    statedb.set(DatabaseKeys.FEELINGS_INDEX, 2)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT, 3)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE, 3)
     with freezegun.freeze_time("2021-04-05"):
         assert not interaction_manager._is_do_goal_setting()
 
     first_interaction_datetime = datetime.datetime(2021, 4, 1, 12, 0, 0)
-    statedb.set("first interaction datetime", first_interaction_datetime)
-    statedb.set("feelings index", 2)
-    statedb.set("num of days since last prompt", 3)
-    statedb.set("num of days since last perseverance", 3)
-    statedb.set("num of days since last goal setting", 6)
-    statedb.set("last 5 eval scores", [5, 5, 5, 5, 5])
-    statedb.set("current eval score", 4)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
+    statedb.set(DatabaseKeys.FEELINGS_INDEX, 2)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT, 3)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE, 3)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING, 6)
+    statedb.set(DatabaseKeys.LAST_5_EVAL_SCORES, [5, 5, 5, 5, 5])
+    statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 4)
     with freezegun.freeze_time("2021-04-10"):
         assert not interaction_manager._is_do_goal_setting()
-        statedb.set("num of days since last goal setting", 7)
+        statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING, 7)
         assert interaction_manager._is_do_goal_setting()
 
 
 def test_determine_is_do_mindfulness(interaction_manager, statedb):
     # less than a week after first interaction
     first_interaction_datetime = datetime.datetime(2021, 4, 1, 12, 0, 0)
-    statedb.set("first interaction datetime", first_interaction_datetime)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
     with freezegun.freeze_time("2021-04-05"):
         assert not interaction_manager._is_do_mindfulness()
 
     first_interaction_datetime = datetime.datetime(2021, 4, 1, 12, 0, 0)
-    statedb.set("first interaction datetime", first_interaction_datetime)
-    statedb.set("feelings index", 2)
-    statedb.set("num of days since last mindfulness", 2)
-    statedb.set("last 5 eval scores", [5, 5, 5, 5, 5])
-    statedb.set("current eval score", 4)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
+    statedb.set(DatabaseKeys.FEELINGS_INDEX, 2)
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS, 2)
+    statedb.set(DatabaseKeys.LAST_5_EVAL_SCORES, [5, 5, 5, 5, 5])
+    statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 4)
     with freezegun.freeze_time("2021-04-10"):
         assert interaction_manager._is_do_mindfulness()

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_manager.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_interaction_manager.py
@@ -4,8 +4,7 @@ import freezegun
 import pytest
 
 from controllers import InteractionManager
-from controllers.interaction_manager import Interactions
-from controllers.vision_project_delegator import DatabaseKeys
+from vision_project_tools.constants import DatabaseKeys, Interactions
 from vision_project_tools.vision_engine import VisionInteractionEngine as InteractionEngine
 
 

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
@@ -4,8 +4,7 @@ import freezegun
 import pytest
 
 from controllers import VisionProjectDelegator
-from controllers.interaction_manager import Interactions
-from controllers.vision_project_delegator import DatabaseKeys
+from vision_project_tools.constants import DatabaseKeys,Interactions
 
 
 @pytest.fixture

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
@@ -197,6 +197,11 @@ def test_new_day_update(vision_project_delegator, statedb):
                 "num of days since last goal setting": 1,
             }
             check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", False)
+            statedb.set("is done prompted today", False)
+            statedb.set("is done perseverance today", False)
+            statedb.set("is done mindfulness today", False)
+            statedb.set("is done goal setting today", False)
         # day 3
         with freezegun.freeze_time(period[2]):
             vision_project_delegator.update()
@@ -310,5 +315,228 @@ def test_new_day_update(vision_project_delegator, statedb):
                 "num of days since last perseverance": 2,
                 "num of days since last mindfulness": 1,
                 "num of days since last goal setting": 0,
+            }
+            check_database_values(statedb, **expected_values)
+
+
+def test_reading_evaluator(vision_project_delegator, statedb):
+    test_periods = [
+        [
+            "2021-03-15 00:00:00",
+            "2021-03-16 00:00:00",
+            "2021-03-17 00:00:00",
+            "2021-03-18 00:00:00",
+            "2021-03-19 00:00:00",
+            "2021-03-20 00:00:00",
+            "2021-03-21 00:00:00",
+            "2021-03-22 00:00:00",
+            "2021-03-23 00:00:00",
+        ],
+        # month changes during test period
+        [
+            "2021-02-25 00:00:00",
+            "2021-02-26 00:00:00",
+            "2021-02-27 00:00:00",
+            "2021-02-28 00:00:00",
+            "2021-03-01 00:00:00",
+            "2021-03-02 00:00:00",
+            "2021-03-03 00:00:00",
+            "2021-03-04 00:00:00",
+            "2021-03-05 00:00:00",
+        ],
+        # year changes during test period
+        [
+            "2020-12-29 00:00:00",
+            "2020-12-30 00:00:00",
+            "2020-12-31 00:00:00",
+            "2021-01-01 00:00:00",
+            "2021-01-02 00:00:00",
+            "2021-01-03 00:00:00",
+            "2021-01-04 00:00:00",
+            "2021-01-05 00:00:00",
+            "2021-01-06 00:00:00",
+        ]
+    ]
+    for period in test_periods:
+        vision_project_delegator._reset_database()
+        # day 1
+        with freezegun.freeze_time(period[0]):
+            vision_project_delegator.update()
+            first_interaction_datetime = datetime.datetime(2021, 3, 15, 2, 0, 0, 0)
+            statedb.set("first interaction datetime", first_interaction_datetime)
+            statedb.set("last interaction datetime", first_interaction_datetime)
+            statedb.set("is done eval today", True)
+            statedb.set("current eval score", 1)
+        # day 2
+        with freezegun.freeze_time(period[1]):
+            vision_project_delegator.update()
+            expected_values = {
+                "num of days since last eval": 0,
+                "num of days since last prompt": 1,
+                "num of days since last perseverance": 1,
+                "num of days since last mindfulness": 1,
+                "num of days since last goal setting": 1,
+                "last 5 eval scores": [1],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 3)
+        # day 3
+        with freezegun.freeze_time(period[2]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [1, 3],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 2)
+        # day 4
+        with freezegun.freeze_time(period[3]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [1, 3, 2],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 5)
+        # day 5
+        with freezegun.freeze_time(period[4]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [1, 3, 2, 5],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 3)
+        # day 6
+        with freezegun.freeze_time(period[5]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [1, 3, 2, 5, 3],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 3)
+        # day 7
+        with freezegun.freeze_time(period[6]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [3, 2, 5, 3, 3],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 5)
+        # day 8
+        with freezegun.freeze_time(period[7]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [2, 5, 3, 3, 5],
+            }
+            check_database_values(statedb, **expected_values)
+            statedb.set("is done eval today", True)
+            statedb.set("is done prompted today", True)
+            statedb.set("is done perseverance today", True)
+            statedb.set("is done mindfulness today", True)
+            statedb.set("is done goal setting today", True)
+            statedb.set("current eval score", 1)
+        # day 9
+        with freezegun.freeze_time(period[8]):
+            vision_project_delegator.update()
+            expected_values = {
+                "is done eval today": False,
+                "is done prompted today": False,
+                "is done perseverance today": False,
+                "is done mindfulness today": False,
+                "is done goal setting today": False,
+                "num of days since last eval": 0,
+                "num of days since last prompt": 0,
+                "num of days since last perseverance": 0,
+                "num of days since last mindfulness": 0,
+                "num of days since last goal setting": 0,
+                "last 5 eval scores": [5, 3, 3, 5, 1],
             }
             check_database_values(statedb, **expected_values)

--- a/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
+++ b/src/ros_vision_interaction/src/vision-interaction/tests/test_vision_project_delegator.py
@@ -4,6 +4,8 @@ import freezegun
 import pytest
 
 from controllers import VisionProjectDelegator
+from controllers.interaction_manager import Interactions
+from controllers.vision_project_delegator import DatabaseKeys
 
 
 @pytest.fixture
@@ -24,17 +26,17 @@ def check_database_values(statedb, **kwargs):
 def test_determine_first_interaction(vision_project_delegator, statedb):
     assert vision_project_delegator._is_first_interaction()
     assert not vision_project_delegator._is_time_for_scheduled_interaction()
-    statedb.set("first interaction datetime", datetime.datetime(2021, 1, 15, 6, 0, 0))
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 15, 6, 0, 0))
     assert not vision_project_delegator._is_first_interaction()
 
 
 def test_determine_scheduled_interaction_not_prompted(vision_project_delegator, statedb):
-    statedb.set("first interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
-    statedb.set("last interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
-    statedb.set("is prompted by user", False)
-    statedb.set("is done eval today", False)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.LAST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.IS_PROMPTED_BY_USER, False)
+    statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, False)
     next_checkin_time = datetime.datetime(2021, 1, 12, 12, 0, 0, 0)
-    statedb.set("next checkin datetime", next_checkin_time)
+    statedb.set(DatabaseKeys.NEXT_CHECKIN_DATETIME, next_checkin_time)
 
     scheduled_window_times = [
         "2021-1-12 11:59:46",
@@ -47,7 +49,7 @@ def test_determine_scheduled_interaction_not_prompted(vision_project_delegator, 
     for valid_time in scheduled_window_times:
         with freezegun.freeze_time(valid_time):
             assert vision_project_delegator._is_time_for_scheduled_interaction()
-            assert vision_project_delegator.get_interaction_type() == "scheduled interaction"
+            assert vision_project_delegator.get_interaction_type() == Interactions.SCHEDULED_INTERACTION
 
     outside_scheduled_window_times = [
         "2021-1-12 2:00:00",
@@ -62,12 +64,12 @@ def test_determine_scheduled_interaction_not_prompted(vision_project_delegator, 
 
 
 def test_determine_interaction_prompted_no_evaluation(vision_project_delegator, statedb):
-    statedb.set("first interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
-    statedb.set("last interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.LAST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
     next_checkin_time = datetime.datetime(2021, 1, 12, 12, 0, 0, 0)
-    statedb.set("next checkin datetime", next_checkin_time)
-    statedb.set("is prompted by user", True)
-    statedb.set("is done eval today", False)
+    statedb.set(DatabaseKeys.NEXT_CHECKIN_DATETIME, next_checkin_time)
+    statedb.set(DatabaseKeys.IS_PROMPTED_BY_USER, True)
+    statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, False)
     # check scheduled interaction is called when within scheduled interaction window and evaluation not done yet
     # window of +/- 15 minutes
     scheduled_window_times = [
@@ -79,7 +81,7 @@ def test_determine_interaction_prompted_no_evaluation(vision_project_delegator, 
     ]
     for valid_time in scheduled_window_times:
         with freezegun.freeze_time(valid_time):
-            assert vision_project_delegator.get_interaction_type() == "scheduled interaction"
+            assert vision_project_delegator.get_interaction_type() == Interactions.SCHEDULED_INTERACTION
     # check 'ask to run prompted' called when not within scheduled interaction window and evaluation not done yet
     scheduled_window_times = [
         "2021-1-12 11:44:59",
@@ -90,16 +92,16 @@ def test_determine_interaction_prompted_no_evaluation(vision_project_delegator, 
     ]
     for valid_time in scheduled_window_times:
         with freezegun.freeze_time(valid_time):
-            assert vision_project_delegator.get_interaction_type() == "ask to do scheduled"
+            assert vision_project_delegator.get_interaction_type() == Interactions.ASK_TO_DO_SCHEDULED
 
 
 def test_determine_interaction_prompted_evaluation_done(vision_project_delegator, statedb):
-    statedb.set("first interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
-    statedb.set("last interaction datetime", datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
+    statedb.set(DatabaseKeys.LAST_INTERACTION_DATETIME, datetime.datetime(2021, 1, 10, 6, 0, 0))
     next_checkin_time = datetime.datetime(2021, 1, 12, 12, 0, 0, 0)
-    statedb.set("next checkin datetime", next_checkin_time)
-    statedb.set("is prompted by user", True)
-    statedb.set("is done eval today", True)
+    statedb.set(DatabaseKeys.NEXT_CHECKIN_DATETIME, next_checkin_time)
+    statedb.set(DatabaseKeys.IS_PROMPTED_BY_USER, True)
+    statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
     # check that prompted interaction is called when evaluation has been done and QT is prompted
     times = [
         "2021-1-12 2:00:00",
@@ -112,37 +114,37 @@ def test_determine_interaction_prompted_evaluation_done(vision_project_delegator
     ]
     for time in times:
         with freezegun.freeze_time(time):
-            assert vision_project_delegator.get_interaction_type() == "prompted interaction"
+            assert vision_project_delegator.get_interaction_type() == Interactions.PROMPTED_INTERACTION
 
 
 def test_is_done_reading_evaluation(vision_project_delegator, statedb):
-    statedb.set("first interaction datetime", datetime.datetime(2021, 2, 9, 6, 0, 0))
-    statedb.set("next checkin datetime", datetime.datetime(2021, 2, 11, 2, 0, 0))
-    statedb.set("last update datetime", datetime.datetime(2021, 2, 10, 12, 0, 0))
-    statedb.set("num of days since last eval", 0)
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 2, 9, 6, 0, 0))
+    statedb.set(DatabaseKeys.NEXT_CHECKIN_DATETIME, datetime.datetime(2021, 2, 11, 2, 0, 0))
+    statedb.set(DatabaseKeys.LAST_UPDATE_DATETIME, datetime.datetime(2021, 2, 10, 12, 0, 0))
+    statedb.set(DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL, 0)
 
     # check scheduled interaction is called when valid time and evaluation not done yet
     with freezegun.freeze_time("2021-02-11 2:00:00"):
-        assert statedb.get("last update datetime") == datetime.datetime(2021, 2, 10, 12, 0, 0)
+        assert statedb.get(DatabaseKeys.LAST_UPDATE_DATETIME) == datetime.datetime(2021, 2, 10, 12, 0, 0)
         vision_project_delegator.update()
-        assert not statedb.get("is done eval today")
-        assert vision_project_delegator.get_interaction_type() == "scheduled interaction"
+        assert not statedb.get(DatabaseKeys.IS_DONE_EVAL_TODAY)
+        assert vision_project_delegator.get_interaction_type() == Interactions.SCHEDULED_INTERACTION
 
         # check no interaction is called when valid time but evaluation already done
         with freezegun.freeze_time("2021-02-11 2:00:00"):
-            statedb.set("is done eval today", True)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
             assert vision_project_delegator.get_interaction_type() is None
 
 
 def test_too_many_prompts(vision_project_delegator, statedb):
-    statedb.set("first interaction datetime", datetime.datetime(2021, 2, 9, 6, 0, 0))
-    statedb.set("last update datetime", datetime.datetime(2021, 2, 10, 12, 0, 0))
+    statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, datetime.datetime(2021, 2, 9, 6, 0, 0))
+    statedb.set(DatabaseKeys.LAST_UPDATE_DATETIME, datetime.datetime(2021, 2, 10, 12, 0, 0))
     next_checkin_time = datetime.datetime(2021, 2, 10, 12, 0, 0)
-    statedb.set("next checkin datetime", next_checkin_time)
-    statedb.set("num of prompted today", 3)
-    statedb.set("is prompted by user", True)
-    statedb.set("is done eval today", True)
-    assert vision_project_delegator.get_interaction_type() == "too many prompted"
+    statedb.set(DatabaseKeys.NEXT_CHECKIN_DATETIME, next_checkin_time)
+    statedb.set(DatabaseKeys.NUM_OF_PROMPTED_TODAY, 3)
+    statedb.set(DatabaseKeys.IS_PROMPTED_BY_USER, True)
+    statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+    assert vision_project_delegator.get_interaction_type() == Interactions.TOO_MANY_PROMPTED
 
 
 def test_new_day_update(vision_project_delegator, statedb):
@@ -183,138 +185,138 @@ def test_new_day_update(vision_project_delegator, statedb):
         with freezegun.freeze_time(period[0]):
             vision_project_delegator.update()
             first_interaction_datetime = datetime.datetime(2021, 3, 15, 2, 0, 0, 0)
-            statedb.set("first interaction datetime", first_interaction_datetime)
-            statedb.set("last interaction datetime", first_interaction_datetime)
-            statedb.set("is done eval today", True)
+            statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
+            statedb.set(DatabaseKeys.LAST_INTERACTION_DATETIME, first_interaction_datetime)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
         # day 2
         with freezegun.freeze_time(period[1]):
             vision_project_delegator.update()
             expected_values = {
-                "num of days since last eval": 0,
-                "num of days since last prompt": 1,
-                "num of days since last perseverance": 1,
-                "num of days since last mindfulness": 1,
-                "num of days since last goal setting": 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 1,
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", False)
-            statedb.set("is done prompted today", False)
-            statedb.set("is done perseverance today", False)
-            statedb.set("is done mindfulness today", False)
-            statedb.set("is done goal setting today", False)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, False)
         # day 3
         with freezegun.freeze_time(period[2]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
             }
             check_database_values(statedb, **expected_values)
             expected_values = {
-                "num of days since last eval": 1,
-                "num of days since last prompt": 2,
-                "num of days since last perseverance": 2,
-                "num of days since last mindfulness": 2,
-                "num of days since last goal setting": 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 2,
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
         # day 4
         with freezegun.freeze_time(period[3]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
             }
             check_database_values(statedb, **expected_values)
             expected_values = {
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
         # day 5
         with freezegun.freeze_time(period[4]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
             }
             check_database_values(statedb, **expected_values)
             expected_values = {
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", False)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", False)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
         # day 6
         with freezegun.freeze_time(period[5]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
             }
             check_database_values(statedb, **expected_values)
             expected_values = {
-                "num of days since last eval": 1,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 1,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", False)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", False)
-            statedb.set("is done mindfulness today", False)
-            statedb.set("is done goal setting today", True)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, False)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
         # day 7
         with freezegun.freeze_time(period[6]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
             }
             check_database_values(statedb, **expected_values)
             expected_values = {
-                "num of days since last eval": 2,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 2,
-                "num of days since last mindfulness": 1,
-                "num of days since last goal setting": 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 2,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
             }
             check_database_values(statedb, **expected_values)
 
@@ -363,180 +365,180 @@ def test_reading_evaluator(vision_project_delegator, statedb):
         with freezegun.freeze_time(period[0]):
             vision_project_delegator.update()
             first_interaction_datetime = datetime.datetime(2021, 3, 15, 2, 0, 0, 0)
-            statedb.set("first interaction datetime", first_interaction_datetime)
-            statedb.set("last interaction datetime", first_interaction_datetime)
-            statedb.set("is done eval today", True)
-            statedb.set("current eval score", 1)
+            statedb.set(DatabaseKeys.FIRST_INTERACTION_DATETIME, first_interaction_datetime)
+            statedb.set(DatabaseKeys.LAST_INTERACTION_DATETIME, first_interaction_datetime)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 1)
         # day 2
         with freezegun.freeze_time(period[1]):
             vision_project_delegator.update()
             expected_values = {
-                "num of days since last eval": 0,
-                "num of days since last prompt": 1,
-                "num of days since last perseverance": 1,
-                "num of days since last mindfulness": 1,
-                "num of days since last goal setting": 1,
-                "last 5 eval scores": [1],
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 1,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 1,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [1],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 3)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 3)
         # day 3
         with freezegun.freeze_time(period[2]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [1, 3],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [1, 3],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 2)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 2)
         # day 4
         with freezegun.freeze_time(period[3]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [1, 3, 2],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [1, 3, 2],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 5)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 5)
         # day 5
         with freezegun.freeze_time(period[4]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [1, 3, 2, 5],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [1, 3, 2, 5],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 3)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 3)
         # day 6
         with freezegun.freeze_time(period[5]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [1, 3, 2, 5, 3],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [1, 3, 2, 5, 3],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 3)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 3)
         # day 7
         with freezegun.freeze_time(period[6]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [3, 2, 5, 3, 3],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [3, 2, 5, 3, 3],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 5)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 5)
         # day 8
         with freezegun.freeze_time(period[7]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [2, 5, 3, 3, 5],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [2, 5, 3, 3, 5],
             }
             check_database_values(statedb, **expected_values)
-            statedb.set("is done eval today", True)
-            statedb.set("is done prompted today", True)
-            statedb.set("is done perseverance today", True)
-            statedb.set("is done mindfulness today", True)
-            statedb.set("is done goal setting today", True)
-            statedb.set("current eval score", 1)
+            statedb.set(DatabaseKeys.IS_DONE_EVAL_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PROMPTED_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_MINDFULNESS_TODAY, True)
+            statedb.set(DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY, True)
+            statedb.set(DatabaseKeys.CURRENT_EVAL_SCORE, 1)
         # day 9
         with freezegun.freeze_time(period[8]):
             vision_project_delegator.update()
             expected_values = {
-                "is done eval today": False,
-                "is done prompted today": False,
-                "is done perseverance today": False,
-                "is done mindfulness today": False,
-                "is done goal setting today": False,
-                "num of days since last eval": 0,
-                "num of days since last prompt": 0,
-                "num of days since last perseverance": 0,
-                "num of days since last mindfulness": 0,
-                "num of days since last goal setting": 0,
-                "last 5 eval scores": [5, 3, 3, 5, 1],
+                DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+                DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+                DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+                DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+                DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+                DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+                DatabaseKeys.LAST_5_EVAL_SCORES: [5, 3, 3, 5, 1],
             }
             check_database_values(statedb, **expected_values)

--- a/src/ros_vision_interaction/src/vision-interaction/vision_project_tools/__init__.py
+++ b/src/ros_vision_interaction/src/vision-interaction/vision_project_tools/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from vision_project_tools.constants import DatabaseKeys, INITIAL_STATE_DB, Interactions
 from vision_project_tools.engine_statedb import EngineStateDb
 from vision_project_tools.vision_engine import VisionInteractionEngine
 

--- a/src/ros_vision_interaction/src/vision-interaction/vision_project_tools/constants.py
+++ b/src/ros_vision_interaction/src/vision-interaction/vision_project_tools/constants.py
@@ -1,0 +1,112 @@
+class Interactions:
+
+    ASK_TO_DO_SCHEDULED = "ask to do scheduled"
+    EVALUATION = "evaluation"
+    FIRST_INTERACTION = "first interaction"
+    PROMPTED_INTERACTION = "prompted interaction"
+    SCHEDULED_INTERACTION = "scheduled interaction"
+    TOO_MANY_PROMPTED = "too many prompted"
+
+    POSSIBLE_INTERACTIONS = [
+        ASK_TO_DO_SCHEDULED,
+        EVALUATION,
+        FIRST_INTERACTION,
+        PROMPTED_INTERACTION,
+        SCHEDULED_INTERACTION,
+        TOO_MANY_PROMPTED
+    ]
+
+
+class DatabaseKeys:
+    BEST_SCORE = "best score"
+    CURRENT_EVAL_SCORE = "current eval score"
+    CURRENT_READING_COLOR = "current reading color"
+    CURRENT_READING_ID = "current reading id"
+    DIFFICULTY_LEVEL = "difficulty level"
+    FEEDBACK_VIDEOS = "feedback videos"
+    FIRST_INTERACTION_DATETIME = "first interaction datetime"
+    GOOD_TO_CHAT = "good to chat"
+    GRIT_FEEDBACK_INDEX = "grit feedback index"
+    IS_CONTINUE_PERSEVERANCE = "is continue perseverance"
+    IS_DO_EVALUATION = "is do evaluation"
+    IS_DONE_EVAL_TODAY = "is done eval today"
+    IS_DONE_GOAL_SETTING_TODAY = "is done goal setting today"
+    IS_DONE_MINDFULNESS_TODAY = "is done mindfulness today"
+    IS_DONE_PERSEVERANCE_TODAY = "is done perseverance today"
+    IS_DONE_PROMPTED_TODAY = "is done prompted today"
+    IS_INTERACTION_FINISHED = "is interaction finished"
+    IS_NEW_DIFFICULTY_LEVEL = "is new difficulty level"
+    IS_OFF_CHECKIN = "is off checkin"
+    IS_PROMPTED_BY_USER = "is prompted by user"
+    IS_PUBLISHED_CHOICES_TODAY = "is published choices today"
+    IS_START_PERSEVERANCE = "is start perseverance"
+    IS_USED_MAGNIFIER_TODAY = "is used magnifier today"
+    LAST_5_EVAL_SCORES = "last 5 eval scores"
+    LAST_INTERACTION_DATETIME = "last interaction datetime"
+    LAST_UPDATE_DATETIME = "last update datetime"
+    LAST_SCORE = "last score"
+    FEELINGS_INDEX = "feelings index"
+    NEXT_CHECKIN_DATETIME = "next checkin datetime"
+    NUM_OF_DAYS_SINCE_LAST_EVAL = "num of days since last eval"
+    NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING = "num of days since last goal setting"
+    NUM_OF_DAYS_SINCE_LAST_MINDFULNESS = "num of days since last mindfulness"
+    NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE = "num of days since last perseverance"
+    NUM_OF_DAYS_SINCE_LAST_PROMPT = "num of days since last prompt"
+    NUM_OF_PROMPTED_TODAY = "num of prompted today"
+    PERSEVERANCE_COUNTER = "perseverance counter"
+    READING_EVAL_DATA = "reading eval data"
+    READING_EVAL_INDEX = "reading eval index"
+    READING_EVAL_TYPE = "reading eval type"
+    USER_NAME = "user name"
+    VIDEO_TO_PLAY = "video to play"
+
+
+INITIAL_STATE_DB = {
+    DatabaseKeys.BEST_SCORE: None,
+    DatabaseKeys.CURRENT_EVAL_SCORE: 0,
+    DatabaseKeys.CURRENT_READING_COLOR: None,
+    DatabaseKeys.CURRENT_READING_ID: None,
+    DatabaseKeys.DIFFICULTY_LEVEL: 1,
+    DatabaseKeys.FEEDBACK_VIDEOS: {
+        "video 1": "https://www.youtube.com/embed/4b33NTAuF5E",
+        "video 2": "https://www.youtube.com/embed/JXeJANDKwDc",
+        "video 3": "https://www.youtube.com/embed/uzkD5SeuwzM",
+        "video 4": "https://www.youtube.com/embed/QqsLTNkzvaY",
+        "no video": ""
+    },
+    DatabaseKeys.FIRST_INTERACTION_DATETIME: None,
+    DatabaseKeys.GOOD_TO_CHAT: None,
+    DatabaseKeys.GRIT_FEEDBACK_INDEX: 0,
+    DatabaseKeys.IS_CONTINUE_PERSEVERANCE: None,
+    DatabaseKeys.IS_DO_EVALUATION: None,
+    DatabaseKeys.IS_DONE_EVAL_TODAY: False,
+    DatabaseKeys.IS_DONE_GOAL_SETTING_TODAY: False,
+    DatabaseKeys.IS_DONE_MINDFULNESS_TODAY: False,
+    DatabaseKeys.IS_DONE_PERSEVERANCE_TODAY: False,
+    DatabaseKeys.IS_DONE_PROMPTED_TODAY: False,
+    DatabaseKeys.IS_INTERACTION_FINISHED: False,
+    DatabaseKeys.IS_NEW_DIFFICULTY_LEVEL: False,
+    DatabaseKeys.IS_OFF_CHECKIN: None,
+    DatabaseKeys.IS_PROMPTED_BY_USER: False,
+    DatabaseKeys.IS_PUBLISHED_CHOICES_TODAY: False,
+    DatabaseKeys.IS_START_PERSEVERANCE: False,
+    DatabaseKeys.IS_USED_MAGNIFIER_TODAY: False,
+    DatabaseKeys.LAST_5_EVAL_SCORES: [],
+    DatabaseKeys.LAST_INTERACTION_DATETIME: None,
+    DatabaseKeys.LAST_UPDATE_DATETIME: None,
+    DatabaseKeys.LAST_SCORE: None,
+    DatabaseKeys.FEELINGS_INDEX: None,
+    DatabaseKeys.NEXT_CHECKIN_DATETIME: None,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_EVAL: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_GOAL_SETTING: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_MINDFULNESS: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PERSEVERANCE: 0,
+    DatabaseKeys.NUM_OF_DAYS_SINCE_LAST_PROMPT: 0,
+    DatabaseKeys.NUM_OF_PROMPTED_TODAY: 0,
+    DatabaseKeys.PERSEVERANCE_COUNTER: 0,
+    DatabaseKeys.READING_EVAL_DATA: [],
+    DatabaseKeys.READING_EVAL_INDEX: 0,
+    DatabaseKeys.READING_EVAL_TYPE: None,
+    DatabaseKeys.USER_NAME: "",
+    DatabaseKeys.VIDEO_TO_PLAY: None
+}


### PR DESCRIPTION
Added the reading evaluator node and the necessary ROS publishers, database keys, and delegator logic to manage the long-term reading tasks. The `ReadingEvaluator` class methods were adapted from py-webrtcvad's [example script](https://github.com/wiseman/py-webrtcvad/blob/master/example.py).